### PR TITLE
remove typo that prevents includedir sudoers.d from working

### DIFF
--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -24,4 +24,4 @@ Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
 %<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
 <% end -%>
 
-<%= "#includedir #{node['authorization']['sudo']['prefix']}/sudoers.d" if @include_sudoers_d  %>
+<%= "includedir #{node['authorization']['sudo']['prefix']}/sudoers.d" if @include_sudoers_d  %>


### PR DESCRIPTION
because even if the `node['authorization']['sudo']['include_sudoers_d']` option set this bug prevents `includedir sudoers.d` from being applied.