### PR TITLE
Defaulted sudoers.d include to true

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 default['authorization']['sudo']['groups']            = ['sysadmin']
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
-default['authorization']['sudo']['include_sudoers_d'] = false
+default['authorization']['sudo']['include_sudoers_d'] = true
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']
 default['authorization']['sudo']['command_aliases']   = []


### PR DESCRIPTION
Defaulted sudoers.d directory include to true.

This breaks test-kitchen converges with the vagrant driver if set to false as the vagrant user is setup in sudoers.d. This means overriding .kitchen.yml to set default['authorization']['sudo']['include_sudoers_d']  to true.

In Centos 6.6+ and Ubuntu 12.04+  it is the default behaviour to include sudoers.d from the sudoers file. 